### PR TITLE
truncate with endidx

### DIFF
--- a/examples/pad_fastq.rs
+++ b/examples/pad_fastq.rs
@@ -33,7 +33,12 @@ fn main() {
                 overlap: 1.0,
             },
         )
-        .pad(sel!(seq1.adapter_2), [label!(seq1.adapter_2)], LeftEnd(6), b'0')
+        .pad(
+            sel!(seq1.adapter_2),
+            [label!(seq1.adapter_2)],
+            LeftEnd(10),
+            b'0',
+        )
         .dbg(sel!())
         .collect_fastq1(sel!(), "example_output/pad.fastq")
         .run()

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -20,6 +20,9 @@ use revcomp_reads::*;
 pub mod pad_reads;
 use pad_reads::*;
 
+pub mod truncate_reads;
+use truncate_reads::*;
+
 pub mod collect_fastq_reads;
 use collect_fastq_reads::*;
 
@@ -177,6 +180,9 @@ pub trait Reads: Send + Sync {
         LengthInBoundsReads::new(self, selector_expr, transform_expr, bounds)
     }
 
+    /// Pad mappings corresponding labels to specific length
+    /// 
+    /// Use `max_length: EndIdx` to specify the length and end of read to pad from
     #[must_use]
     fn pad(
         self,
@@ -189,6 +195,22 @@ pub trait Reads: Send + Sync {
         Self: Sized,
     {
         PadReads::new(self, selector_expr, labels.into(), max_length, pad_char)
+    }
+
+    /// Truncate mappings corresponding labels to specific length
+    /// 
+    /// Use `max_length: EndIdx` to specify the length and end of read to truncate from
+    #[must_use]
+    fn trunc(
+        self,
+        selector_expr: SelectorExpr,
+        labels: impl Into<Vec<Label>>,
+        max_length: EndIdx,
+    ) -> TruncateReads<Self>
+    where
+        Self: Sized,
+    {
+        TruncateReads::new(self, selector_expr, labels.into(), max_length)
     }
 
     /// Set mappings corresponding labels to their reverse complement

--- a/src/iter/truncate_reads.rs
+++ b/src/iter/truncate_reads.rs
@@ -1,0 +1,59 @@
+use crate::iter::*;
+
+pub struct TruncateReads<R: Reads> {
+    reads: R,
+    selector_expr: SelectorExpr,
+    labels: Vec<Label>,
+    max_length: EndIdx,
+}
+
+impl<R: Reads> TruncateReads<R> {
+    pub fn new(
+        reads: R,
+        selector_expr: SelectorExpr,
+        labels: Vec<Label>,
+        max_length: EndIdx,
+    ) -> Self {
+        Self {
+            reads,
+            selector_expr,
+            labels,
+            max_length,
+        }
+    }
+}
+
+impl<R: Reads> Reads for TruncateReads<R> {
+    fn next_chunk(&self) -> Result<Vec<Read>> {
+        let mut reads = self.reads.next_chunk()?;
+
+        for read in reads.iter_mut() {
+            if !(self
+                .selector_expr
+                .matches(read)
+                .map_err(|e| Error::NameError {
+                    source: e,
+                    read: read.clone(),
+                    context: "truncate reads",
+                })?)
+            {
+                continue;
+            }
+
+            self.labels
+                .iter()
+                .try_for_each(|l| read.truncate(l.str_type, l.label, self.max_length))
+                .map_err(|e| Error::NameError {
+                    source: e,
+                    read: read.clone(),
+                    context: "truncate reads",
+                })?;
+        }
+
+        Ok(reads)
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        self.reads.finish()
+    }
+}


### PR DESCRIPTION
small bug fix in pad and documentation.

Truncate with end idx